### PR TITLE
Extends activation metrics model

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 rootProject.name=activation
 profile=dev
-version=2.0.23
+version=2.0.24
 
 # Build properties
 node_version=12.13.0

--- a/src/main/java/com/icthh/xm/tmf/ms/activation/config/SagaTransactionSpecificationMetric.java
+++ b/src/main/java/com/icthh/xm/tmf/ms/activation/config/SagaTransactionSpecificationMetric.java
@@ -1,0 +1,72 @@
+package com.icthh.xm.tmf.ms.activation.config;
+
+import static com.icthh.xm.tmf.ms.activation.domain.SagaEvent.SagaEventStatus.SUSPENDED;
+import static com.icthh.xm.tmf.ms.activation.domain.SagaTransactionState.NEW;
+import static java.time.Instant.now;
+
+import com.codahale.metrics.Gauge;
+import com.codahale.metrics.Metric;
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.MetricSet;
+import com.icthh.xm.tmf.ms.activation.repository.SagaTransactionRepository;
+import com.icthh.xm.tmf.ms.activation.utils.TenantUtils;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class SagaTransactionSpecificationMetric {
+
+    private static final String METRIC_GROUP_NAME = "com.icthh.xm.tmf.ms.activation.specification";
+    private final SagaTransactionRepository sagaTransactionRepository;
+    private final ApplicationProperties applicationProperties;
+    private final TenantUtils tenantUtils;
+    private final MetricRegistry metricRegistry;
+
+    public SagaTransactionSpecificationMetric(@Lazy SagaTransactionRepository sagaTransactionRepository,
+                                              ApplicationProperties applicationProperties,
+                                              TenantUtils tenantUtils,
+                                              MetricRegistry metricRegistry) {
+        this.sagaTransactionRepository = sagaTransactionRepository;
+        this.applicationProperties = applicationProperties;
+        this.tenantUtils = tenantUtils;
+        this.metricRegistry = metricRegistry;
+    }
+
+    public void initMetrics(String tenant, List<String> specificationKeys) {
+        log.info("initMetrics: tenant: {}, specificationKeys: {}", tenant, specificationKeys);
+
+        metricRegistry.removeMatching((name, metric) -> name.startsWith(METRIC_GROUP_NAME));
+        metricRegistry.register(METRIC_GROUP_NAME, (MetricSet) () -> {
+            Map<String, Metric> metrics = new HashMap<>();
+            specificationKeys.forEach(specKey -> {
+                metrics.put("transactions.wait." + tenant + "." + specKey,
+                    inTenant(() -> this.getWaitTransactionsCount(specKey), tenant));
+                metrics.put("transactions.suspended." + tenant + "." + specKey,
+                    inTenant(() -> this.getTransactionsCountWithSuspendedTasks(specKey), tenant));
+            });
+
+            return metrics;
+        });
+    }
+
+    private Gauge inTenant(Supplier<Long> metricSupplier, String tenant) {
+        return () -> tenantUtils.doInTenantContext(metricSupplier::get, tenant);
+    }
+
+    private long getWaitTransactionsCount(String typeKey) {
+        Instant date = now().minusSeconds(applicationProperties.getExpectedTransactionCompletionTimeSeconds());
+        return sagaTransactionRepository.countByCreateDateBeforeAndSagaTransactionStateAndTypeKey(date, NEW, typeKey);
+    }
+
+    private long getTransactionsCountWithSuspendedTasks(String typeKey) {
+        Instant date = now().minusSeconds(applicationProperties.getExpectedTransactionCompletionTimeSeconds());
+        return sagaTransactionRepository.countByTypeKeyAndEventStatusAndCreatedDateBefore(typeKey, SUSPENDED, date);
+    }
+}

--- a/src/main/java/com/icthh/xm/tmf/ms/activation/repository/ExtendedSagaTransactionRepository.java
+++ b/src/main/java/com/icthh/xm/tmf/ms/activation/repository/ExtendedSagaTransactionRepository.java
@@ -1,0 +1,10 @@
+package com.icthh.xm.tmf.ms.activation.repository;
+
+import com.icthh.xm.tmf.ms.activation.domain.SagaEvent;
+import java.time.Instant;
+
+public interface ExtendedSagaTransactionRepository {
+
+    long countByTypeKeyAndEventStatusAndCreatedDateBefore(String typeKey, SagaEvent.SagaEventStatus eventStatus, Instant date);
+
+}

--- a/src/main/java/com/icthh/xm/tmf/ms/activation/repository/ExtendedSagaTransactionRepositoryImpl.java
+++ b/src/main/java/com/icthh/xm/tmf/ms/activation/repository/ExtendedSagaTransactionRepositoryImpl.java
@@ -1,0 +1,52 @@
+package com.icthh.xm.tmf.ms.activation.repository;
+
+import com.icthh.xm.tmf.ms.activation.domain.SagaEvent;
+import com.icthh.xm.tmf.ms.activation.domain.SagaEvent_;
+import com.icthh.xm.tmf.ms.activation.domain.SagaTransaction;
+import com.icthh.xm.tmf.ms.activation.domain.SagaTransaction_;
+import java.time.Instant;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.ParameterExpression;
+import javax.persistence.criteria.Root;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+@Repository
+@Transactional(readOnly = true)
+public class ExtendedSagaTransactionRepositoryImpl implements ExtendedSagaTransactionRepository {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Override
+    public long countByTypeKeyAndEventStatusAndCreatedDateBefore(String typeKey, SagaEvent.SagaEventStatus eventStatus, Instant date) {
+        CriteriaBuilder criteria = entityManager.getCriteriaBuilder();
+        CriteriaQuery<Long> query = criteria.createQuery(Long.class);
+        Root<SagaTransaction> transaction = query.from(SagaTransaction.class);
+        Root<SagaEvent> event = query.from(SagaEvent.class);
+
+        ParameterExpression<String> typeKeyParam = criteria.parameter(String.class);
+        ParameterExpression<SagaEvent.SagaEventStatus> eventStatusParam = criteria.parameter(SagaEvent.SagaEventStatus.class);
+        ParameterExpression<Instant> createDateParam = criteria.parameter(Instant.class);
+
+        query
+            .select(criteria.count(event.get(SagaEvent_.id)))
+            .where(
+                criteria.and(
+                    criteria.equal(transaction.get(SagaTransaction_.id), event.get(SagaEvent_.transactionId)),
+                    criteria.equal(transaction.get(SagaTransaction_.typeKey), typeKeyParam),
+                    criteria.equal(event.get(SagaEvent_.status), eventStatusParam),
+                    criteria.lessThan(event.get(SagaEvent_.createDate), createDateParam)
+                )
+            );
+
+        return entityManager.createQuery(query)
+            .setParameter(typeKeyParam, typeKey)
+            .setParameter(eventStatusParam, eventStatus)
+            .setParameter(createDateParam, date)
+            .getSingleResult();
+    }
+}

--- a/src/main/java/com/icthh/xm/tmf/ms/activation/repository/SagaTransactionRepository.java
+++ b/src/main/java/com/icthh/xm/tmf/ms/activation/repository/SagaTransactionRepository.java
@@ -8,11 +8,13 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface SagaTransactionRepository extends JpaRepository<SagaTransaction, String> {
+public interface SagaTransactionRepository extends JpaRepository<SagaTransaction, String>, ExtendedSagaTransactionRepository {
 
     Page<SagaTransaction> findAllBySagaTransactionState(SagaTransactionState sagaTransactionState, Pageable pageable);
 
     long countByCreateDateBeforeAndSagaTransactionState(Instant date, SagaTransactionState state);
+
+    long countByCreateDateBeforeAndSagaTransactionStateAndTypeKey(Instant date, SagaTransactionState state, String typeKey);
 
     Optional<SagaTransaction> findByKey(String key);
 

--- a/src/main/java/com/icthh/xm/tmf/ms/activation/service/SagaSpecService.java
+++ b/src/main/java/com/icthh/xm/tmf/ms/activation/service/SagaSpecService.java
@@ -5,14 +5,15 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.icthh.xm.commons.config.client.api.RefreshableConfiguration;
 import com.icthh.xm.commons.exceptions.BusinessException;
 import com.icthh.xm.commons.logging.aop.IgnoreLogginAspect;
+import com.icthh.xm.tmf.ms.activation.config.SagaTransactionSpecificationMetric;
 import com.icthh.xm.tmf.ms.activation.domain.spec.SagaSpec;
 import com.icthh.xm.tmf.ms.activation.domain.spec.SagaTransactionSpec;
 import com.icthh.xm.tmf.ms.activation.utils.TenantUtils;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
-
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
@@ -31,6 +32,7 @@ public class SagaSpecService implements RefreshableConfiguration {
     private final TenantUtils tenantUtils;
     private AntPathMatcher matcher = new AntPathMatcher();
     private ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
+    private final SagaTransactionSpecificationMetric sagaTransactionSpecificationMetric;
 
     @Override
     public void onRefresh(String updatedKey, String config) {
@@ -60,9 +62,22 @@ public class SagaSpecService implements RefreshableConfiguration {
                 sagaSpecs.put(tenant, spec);
                 updateRetryPolicy(spec);
                 log.info("Spec for tenant '{}' were updated: {}", tenant, updatedKey);
+
+                initMetrics(tenant, spec);
             }
         } catch (Exception e) {
             log.error("Error read specification from path: {}", updatedKey, e);
+        }
+    }
+
+    private void initMetrics(String tenant, SagaSpec spec) {
+        try {
+            List<String> specificationKeys = spec.getTransactions().stream()
+                .map(SagaTransactionSpec::getKey)
+                .collect(Collectors.toList());
+            sagaTransactionSpecificationMetric.initMetrics(tenant, specificationKeys);
+        } catch (Exception e) {
+            log.error("Could not init metrics for tenant: {}", tenant, e);
         }
     }
 
@@ -84,7 +99,7 @@ public class SagaSpecService implements RefreshableConfiguration {
         SagaSpec sagaSpec = sagaSpecs.get(tenantKey);
         if (sagaSpec == null) {
             throw new InvalidSagaSpecificationException("saga.spec.not.found",
-                                        "Saga spec for type " + typeKey + " and tenant " + tenantKey + " not found.");
+                "Saga spec for type " + typeKey + " and tenant " + tenantKey + " not found.");
         }
         return sagaSpec.getByType(typeKey);
     }

--- a/src/test/java/com/icthh/xm/tmf/ms/activation/config/SagaTransactionSpecificationMetricTest.java
+++ b/src/test/java/com/icthh/xm/tmf/ms/activation/config/SagaTransactionSpecificationMetricTest.java
@@ -1,0 +1,52 @@
+package com.icthh.xm.tmf.ms.activation.config;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import com.codahale.metrics.Gauge;
+import com.codahale.metrics.Metric;
+import com.codahale.metrics.MetricRegistry;
+import com.icthh.xm.tmf.ms.activation.repository.SagaTransactionRepository;
+import com.icthh.xm.tmf.ms.activation.utils.TenantUtils;
+import java.util.List;
+import java.util.Map;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@RunWith(SpringRunner.class)
+public class SagaTransactionSpecificationMetricTest {
+
+    @Mock
+    private SagaTransactionRepository sagaTransactionRepository;
+    @Mock
+    private ApplicationProperties applicationProperties;
+    @Mock
+    private TenantUtils tenantUtils;
+    @Spy
+    private MetricRegistry metricRegistry;
+
+    @Test
+    public void shouldCreateTransactionMetrics() {
+        // GIVEN
+        SagaTransactionSpecificationMetric sagaTransactionSpecificationMetric =
+            new SagaTransactionSpecificationMetric(sagaTransactionRepository, applicationProperties,
+                tenantUtils, metricRegistry);
+        metricRegistry.meter("com.icthh.xm.tmf.ms.activation.specification");
+
+        // WHEN
+        sagaTransactionSpecificationMetric.initMetrics("XM", List.of("SPEC-1", "SPEC-2"));
+
+        // THEN
+        Map<String, Metric> metrics = metricRegistry.getMetrics();
+        assertEquals(4, metrics.size());
+        assertTrue(metrics.containsKey("com.icthh.xm.tmf.ms.activation.specification.transactions.wait.XM.SPEC-2"));
+        assertTrue(metrics.containsKey("com.icthh.xm.tmf.ms.activation.specification.transactions.suspended.XM.SPEC-2"));
+        assertTrue(metrics.containsKey("com.icthh.xm.tmf.ms.activation.specification.transactions.wait.XM.SPEC-1"));
+        assertTrue(metrics.containsKey("com.icthh.xm.tmf.ms.activation.specification.transactions.suspended.XM.SPEC-1"));
+        assertTrue(metrics.get("com.icthh.xm.tmf.ms.activation.specification.transactions.wait.XM.SPEC-2") instanceof Gauge);
+    }
+
+}

--- a/src/test/java/com/icthh/xm/tmf/ms/activation/repository/RepositoryTest.java
+++ b/src/test/java/com/icthh/xm/tmf/ms/activation/repository/RepositoryTest.java
@@ -1,5 +1,6 @@
 package com.icthh.xm.tmf.ms.activation.repository;
 
+import static com.icthh.xm.tmf.ms.activation.domain.SagaEvent.SagaEventStatus.SUSPENDED;
 import static com.icthh.xm.tmf.ms.activation.domain.SagaTransactionState.CANCELED;
 import static com.icthh.xm.tmf.ms.activation.domain.SagaTransactionState.NEW;
 import static java.util.Arrays.asList;
@@ -12,8 +13,6 @@ import com.icthh.xm.tmf.ms.activation.domain.SagaTransactionState;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
-import java.util.UUID;
-import javax.persistence.PersistenceException;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -62,6 +61,12 @@ public class RepositoryTest extends BaseDaoTest {
     @Test
     public void testCountOldTransaction() {
         assertEquals(2, sagaTransactionRepository.countByCreateDateBeforeAndSagaTransactionState(moveToSystemTime("2019-03-04T13:50:00"), NEW));
+    }
+
+    @Test
+    public void testCountOldTransactionWithSuspendedEvents() {
+        assertEquals(0,
+            sagaTransactionRepository.countByTypeKeyAndEventStatusAndCreatedDateBefore("A", SUSPENDED, moveToSystemTime("2019-03-04T13:50:00")));
     }
 
     public SagaTransaction tx(String id, String typeKey, SagaTransactionState sagaTransactionState, String date) {

--- a/src/test/java/com/icthh/xm/tmf/ms/activation/service/SagaServiceTest.java
+++ b/src/test/java/com/icthh/xm/tmf/ms/activation/service/SagaServiceTest.java
@@ -1,5 +1,6 @@
 package com.icthh.xm.tmf.ms.activation.service;
 
+import com.icthh.xm.tmf.ms.activation.config.SagaTransactionSpecificationMetric;
 import com.icthh.xm.tmf.ms.activation.domain.SagaEvent;
 import com.icthh.xm.tmf.ms.activation.domain.SagaLog;
 import com.icthh.xm.tmf.ms.activation.domain.SagaLogType;
@@ -94,6 +95,8 @@ public class SagaServiceTest {
     private RetryService retryService;
     @Mock
     private SagaEventRepository sagaEventRepository;
+    @Mock
+    private SagaTransactionSpecificationMetric sagaTransactionSpecificationMetric;
     @Captor
     private ArgumentCaptor<SagaLog> sagaLogArgumentCaptor;
     @Captor
@@ -117,13 +120,14 @@ public class SagaServiceTest {
 
     @Before
     public void before() throws IOException {
-        specService = new SagaSpecService(tenantUtils);
+        specService = new SagaSpecService(tenantUtils, sagaTransactionSpecificationMetric);
         sagaService = new SagaServiceImpl(logRepository, transactionRepository, specService, eventsManager,
             tenantUtils, taskExecutor, retryService, sagaEventRepository);
         sagaService.setClock(clock);
         sagaService.setSelf(sagaService);
         specService.onRefresh("/config/tenants/XM/activation/activation-spec.yml", loadFile("spec/activation-spec.yml"));
         when(taskExecutor.onCheckWaitCondition(any(), any(), any())).thenReturn(true);
+        verify(sagaTransactionSpecificationMetric).initMetrics(anyString(), any());
     }
 
     public static String loadFile(String path) throws IOException {


### PR DESCRIPTION
* Separate metric for all transaction keys: now for all spec keys two metrics will be returned: count of old transactions stuck in NEW state and count of transactions with old events in SUSPENDED state