### PR TITLE
fix(SagaServiceImpl): Delete Saga Event entity from DB, if it is finished already

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 rootProject.name=activation
 profile=dev
 
-version=2.0.42
+version=2.0.43
 
 # Build properties
 node_version=12.13.0


### PR DESCRIPTION
Example transaction

```yaml
transactions:
  - key: TRANSACTION
    tasks:
      - key: DO-STUFF
        isSuspendable: true
        next:
          - CALLBACK-HANDLE
          - UNEXPECTED-ERROR
      - key: CALLBACK-HANDLE
      - key: UNEXPECTED-ERROR
```

Test case

1. Launch transaction
2. Execute task with type `DO-STUFF`
3. In `DO-STUFF` set 
   ```groovy
   next = ['CALLBACK-HANDLE']
   ```
4. After `DO-STUFF` execution `com.icthh.xm.tmf.ms.activation.service.SagaServiceImpl.doTask` will invoke `com.icthh.xm.tmf.ms.activation.service.SagaServiceImpl.rejectTask` for `UNEXPECTED-ERROR`. 
5. Invoke REST API `/api/internal/task/{id}/continue` which is processed by `com.icthh.xm.tmf.ms.activation.web.rest.SagaTransactionResource.continueTask`
6. During invocation of `continueTask` `SagaServiceImpl` will invoke `com.icthh.xm.tmf.ms.activation.service.SagaServiceImpl.generateEvents`, which will create `SagaEvent` for **both** of `next` tasks of `DO-STUFF`: `CALLBACK-HANDLE` and `UNEXPECTED-ERROR` even though `UNEXPECTED-ERROR` was rejected in step 4.
7. `UNEXPECTED-ERROR` event will never be processed, because there is `SagaLog` object with status `REJECTED-BY-CONDITION`, leaving this object in DB forever as trash.

The PR removes `SagaEvent` object, if the task has been finished or rejected. 
   