### PR TITLE
feat(metrics): remove redundant metrics

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 rootProject.name=activation
 profile=dev
 
-version=2.0.61
+version=2.0.62
 
 # Build properties
 node_version=12.13.0

--- a/src/main/java/com/icthh/xm/tmf/ms/activation/config/AppMetricsConfiguration.java
+++ b/src/main/java/com/icthh/xm/tmf/ms/activation/config/AppMetricsConfiguration.java
@@ -1,31 +1,14 @@
 package com.icthh.xm.tmf.ms.activation.config;
 
-import static com.icthh.xm.tmf.ms.activation.domain.SagaEvent.SagaEventStatus.ON_RETRY;
-import static com.icthh.xm.tmf.ms.activation.domain.SagaEvent.SagaEventStatus.SUSPENDED;
-import static com.icthh.xm.tmf.ms.activation.domain.SagaTransactionState.NEW;
-import static java.time.Instant.now;
-
-import com.codahale.metrics.Gauge;
-import com.codahale.metrics.Metric;
 import com.codahale.metrics.MetricRegistry;
-import com.codahale.metrics.MetricSet;
-import com.icthh.xm.commons.config.client.repository.TenantListRepository;
-import com.icthh.xm.tmf.ms.activation.repository.SagaEventRepository;
-import com.icthh.xm.tmf.ms.activation.repository.SagaTransactionRepository;
-import com.icthh.xm.tmf.ms.activation.utils.TenantUtils;
 import com.ryantenney.metrics.spring.config.annotation.EnableMetrics;
 import com.ryantenney.metrics.spring.config.annotation.MetricsConfigurerAdapter;
 import com.zaxxer.hikari.HikariDataSource;
-import java.time.Instant;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.function.Supplier;
 import javax.annotation.PostConstruct;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Lazy;
 
 @Configuration
 @EnableMetrics(proxyTargetClass = true)
@@ -33,28 +16,15 @@ public class AppMetricsConfiguration extends MetricsConfigurerAdapter {
 
     private final Logger log = LoggerFactory.getLogger(AppMetricsConfiguration.class);
 
-    private final SagaTransactionRepository sagaTransactionRepository;
-    private final SagaEventRepository sagaEventRepository;
     private final MetricRegistry metricRegistry;
-    private final ApplicationProperties applicationProperties;
     private final ActivationKafkaOffsetsMetric kafkaOffsetsMetric;
-    private final TenantListRepository tenantListRepository;
-    private final TenantUtils tenantUtils;
 
     private HikariDataSource hikariDataSource;
 
-    public AppMetricsConfiguration(@Lazy SagaTransactionRepository sagaTransactionRepository,
-                                   @Lazy SagaEventRepository sagaEventRepository, MetricRegistry metricRegistry,
-                                   TenantListRepository tenantListRepository,
-                                   ApplicationProperties applicationProperties, ActivationKafkaOffsetsMetric kafkaOffsetsMetric,
-                                   TenantUtils tenantUtils) {
-        this.sagaTransactionRepository = sagaTransactionRepository;
-        this.sagaEventRepository = sagaEventRepository;
+    public AppMetricsConfiguration(MetricRegistry metricRegistry,
+                                   ActivationKafkaOffsetsMetric kafkaOffsetsMetric) {
         this.metricRegistry = metricRegistry;
-        this.applicationProperties = applicationProperties;
         this.kafkaOffsetsMetric = kafkaOffsetsMetric;
-        this.tenantListRepository = tenantListRepository;
-        this.tenantUtils = tenantUtils;
     }
 
     @Autowired(required = false)
@@ -72,28 +42,5 @@ public class AppMetricsConfiguration extends MetricsConfigurerAdapter {
             hikariDataSource.setMetricsTrackerFactory(null);
             hikariDataSource.setMetricRegistry(metricRegistry);
         }
-
-        Map<String, Metric> metrics = new HashMap<>();
-        tenantListRepository.getTenants().stream().map(String::toUpperCase).forEach(tenant -> {
-            metrics.put("transactions.wait." + tenant, inTenant(this::getWaitTransactionsCount, tenant));
-            metrics.put("transactions.all." + tenant, inTenant(sagaTransactionRepository::count, tenant));
-            metrics.put("tasks.onretry." + tenant, inTenant(() -> sagaEventRepository.countByStatus(ON_RETRY), tenant));
-            metrics.put("tasks.suspended." + tenant, inTenant(this::getCountSuspendedTasks, tenant));
-        });
-        metricRegistry.register("com.icthh.xm.tmf.ms.activation", (MetricSet) () -> metrics);
-    }
-
-    private Long getCountSuspendedTasks() {
-        Instant date = now().minusSeconds(applicationProperties.getExpectedTransactionCompletionTimeSeconds());
-        return sagaEventRepository.countByStatusAndCreateDateBefore(SUSPENDED, date);
-    }
-
-    private long getWaitTransactionsCount() {
-        Instant date = now().minusSeconds(applicationProperties.getExpectedTransactionCompletionTimeSeconds());
-        return sagaTransactionRepository.countByCreateDateBeforeAndSagaTransactionState(date, NEW);
-    }
-
-    private Gauge inTenant(Supplier<Long> metricSupplier, String tenant) {
-        return () -> tenantUtils.doInTenantContext(metricSupplier::get, tenant);
     }
 }

--- a/src/main/java/com/icthh/xm/tmf/ms/activation/config/ApplicationProperties.java
+++ b/src/main/java/com/icthh/xm/tmf/ms/activation/config/ApplicationProperties.java
@@ -27,7 +27,6 @@ public class ApplicationProperties {
     private List<String> tenantWithCreationAccessList;
     private int kafkaConcurrencyCount;
     private int kafkaOffsetsMetricTimeout;
-    private long expectedTransactionCompletionTimeSeconds;
     private RestTemplateProperties loadBalancedRestTemplate = new RestTemplateProperties();
 
     private final Lep lep = new Lep();

--- a/src/main/resources/config/application.yml
+++ b/src/main/resources/config/application.yml
@@ -183,7 +183,6 @@ xm-config:
 
 application:
     kafkaOffsetsMetricTimeout: 5
-    expectedTransactionCompletionTimeSeconds: 300
     retryThreadCount: 3
     kafka-enabled: true
     kafka-system-topic: system_topic


### PR DESCRIPTION
Reasoning: this configuration of metrics results in each instance of activation microservice query single database, which is redundant. This kind of metrics should be configured in a single standalone component, that will query database only once.