### PR TITLE
Update xm-commons to 5.0.36

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 rootProject.name=activation
 profile=dev
-version=4.0.5
+version=4.0.6
 
 # Dependency versions
 jhipsterFrameworkDependenciesVersion=9.0.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,7 +20,7 @@ springdocOpenapiVersion=2.5.0
 apacheCommonCompress=1.26.0
 gitClassGraph=4.8.112
 
-xm_commons_version=5.0.19
+xm_commons_version=5.0.36
 postgresqlVersion=42.7.7
 undertowVersion=2.3.17.Final
 xnioApiVersion=3.8.14.Final


### PR DESCRIPTION
Bumps `xm_commons_version` from **5.0.19** to **5.0.36**.

## Verification

`./gradlew clean test` on Eclipse Temurin 25.0.1, Gradle 9.2.1:

| | |
|---|---|
| Result | BUILD SUCCESSFUL |
| Tests | **84** |
| Failures | 0 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)