### PR TITLE
Fix /v3/api-docs: move springdoc to the Spring Boot 4 line

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -16,7 +16,7 @@ mapstructVersion=1.6.3
 archunitJunit5Version=1.3.0
 jacksonDatabindNullableVersion=0.2.2
 lombok_version=1.18.42
-springdocOpenapiVersion=2.5.0
+springdocOpenapiVersion=3.0.3
 apacheCommonCompress=1.26.0
 gitClassGraph=4.8.112
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 rootProject.name=activation
 profile=dev
-version=4.0.6
+version=4.0.7
 
 # Dependency versions
 jhipsterFrameworkDependenciesVersion=9.0.0

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -79,7 +79,7 @@
     <ul>
         <li>It does not have a front-end. The front-end should be generated on a JHipster gateway</li>
         <li>It is serving REST APIs, under the '/api' URLs.</li>
-        <li>Swagger documentation endpoint for those APIs is at <a href="./v2/api-docs">/v2/api-docs</a>, but if you want access to the full Swagger UI, you should use a JHipster gateway, which will serve as an API developer portal</li>
+        <li>Swagger documentation endpoint for those APIs is at <a href="./v3/api-docs">/v3/api-docs</a>, but if you want access to the full Swagger UI, you should use a JHipster gateway, which will serve as an API developer portal</li>
     </ul>
 
     <h2>

--- a/src/test/java/com/icthh/xm/tmf/ms/activation/web/rest/ApiDocsIntTest.java
+++ b/src/test/java/com/icthh/xm/tmf/ms/activation/web/rest/ApiDocsIntTest.java
@@ -1,0 +1,39 @@
+package com.icthh.xm.tmf.ms.activation.web.rest;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.icthh.xm.tmf.ms.activation.AbstractSpringBootTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+/**
+ * Guards the OpenAPI document springdoc serves at /v3/api-docs - the endpoint the gateway and
+ * Swagger UI read. Nothing else in the suite touches it, so a broken springdoc setup used to go
+ * unnoticed until runtime.
+ */
+public class ApiDocsIntTest extends AbstractSpringBootTest {
+
+    @Autowired
+    private WebApplicationContext context;
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    public void setup() {
+        this.mockMvc = MockMvcBuilders.webAppContextSetup(context).build();
+    }
+
+    @Test
+    public void apiDocsIsServedAsOpenApi3() throws Exception {
+        mockMvc.perform(get("/v3/api-docs"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.openapi").value(org.hamcrest.Matchers.startsWith("3.")))
+            .andExpect(jsonPath("$.paths").isNotEmpty());
+    }
+}

--- a/src/test/resources/config/application.yml
+++ b/src/test/resources/config/application.yml
@@ -142,4 +142,4 @@ application:
       delay: 100 #in milliseconds
       multiplier: 2
   retryThreadCount: 3
-  tenant-ignored-path-list: /swagger-resources/configuration/ui, /management/health, /h2-console, /v2/api-docs, /api/profile-info, /swagger-resources/configuration/ui, /management/health, /management/prometheus
+  tenant-ignored-path-list: /swagger-resources/configuration/ui, /management/health, /h2-console, /v3/api-docs, /api/profile-info, /swagger-resources/configuration/ui, /management/health, /management/prometheus


### PR DESCRIPTION
Fix /v3/api-docs: move springdoc to the Spring Boot 4 line

springdoc 2.x calls `new ControllerAdviceBean(Object)`. That constructor was
removed in Spring Framework 7, so after the move to Spring Boot 4 every
GET /v3/api-docs answered HTTP 500:

    java.lang.NoSuchMethodError: 'void org.springframework.web.method.ControllerAdviceBean.<init>(java.lang.Object)'
      at org.springdoc.core.service.GenericResponseService.getGenericMapResponse(GenericResponseService.java:708)
      at org.springdoc.webmvc.api.OpenApiWebMvcResource.openapiJson(OpenApiWebMvcResource.java:114)

The app starts clean and /v3/api-docs/swagger-config still answers 200, so
nothing in the logs points at it — it only fails when the document is built.
Per springdoc's compatibility matrix, springdoc 3.x is the line for Boot 4.x.
