### PR TITLE
Update xm-commons to 5.0.39

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 rootProject.name=activation
 profile=dev
-version=4.0.7
+version=4.0.8
 
 # Dependency versions
 jhipsterFrameworkDependenciesVersion=9.0.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,7 +20,7 @@ springdocOpenapiVersion=3.0.3
 apacheCommonCompress=1.26.0
 gitClassGraph=4.8.112
 
-xm_commons_version=5.0.36
+xm_commons_version=5.0.39
 postgresqlVersion=42.7.7
 undertowVersion=2.3.17.Final
 xnioApiVersion=3.8.14.Final


### PR DESCRIPTION
Bumps xm_commons_version from 5.0.36 to 5.0.39, the current release
per Maven Central metadata (published 2026-08-09).

Verified with `./gradlew clean test` on Eclipse Temurin 25 and
Gradle 9.2.1: BUILD SUCCESSFUL, 85 tests, no failures.